### PR TITLE
Fix premature popup dismissal on Ubuntu & ChromeOS

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -74,6 +74,12 @@ var spaces = (function () {
     //add listeners for tab and window focus changes
     //when a tab or window is changed, close the move tab popup if it is open
     chrome.windows.onFocusChanged.addListener(function(windowId) {
+        // Prevent a click in the popup on Ubunto or ChroneOS from closing the
+        // popup prematurely.
+        if (windowId == chrome.windows.WINDOW_ID_NONE || windowId == spacesPopupWindowId) {
+            return;
+        }
+        
         if (!debug && spacesPopupWindowId) {
             if (spacesPopupWindowId) {
                 closePopupWindow();


### PR DESCRIPTION
### Purpose
Fix for Issue #1: "_Popups don't stay open on Ubuntu+Compiz_"

### Credit
Patch due to @tri-bao, who posted it to the Chrome Web Store [support pages](https://chrome.google.com/webstore/detail/spaces/cenkmofngpohdnkbjdpilgpmbiiljjim/support) before the extension was added to GitHub.

### Analysis
On some platforms, clicking in the _**Quick-Switch/Move-Active-Tab**_ popup window triggers an _onFocusChanged_ event, which causes us to dismiss the popup as though the user had clicked in a _real window_.  This patch addresses this corner case.
